### PR TITLE
fix(package.json): correct typos in package name and repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ikhsan-temporary/leaflet-trackplayer",
+  "name": "leaflet-trackplayer",
   "version": "2.0.4",
   "description": "A Leaflet trajectory playback plugin that automatically rotates the marker icon based on the actual direction of travel and dynamically adjusts the colors of the traveled and untraveled distances to clearly indicate the current progress. It also supports custom settings such as driving speed, among other features. Detailed documentation can be found below.",
   "main": "dist/leaflet-trackplayer.umd.cjs",
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Ikhsanheriyawan2404/Leaflet.TrackPlayer.git"
+    "url": "https://github.com/weijun-lab/Leaflet.TrackPlayer.git"
   },
   "author": "Jun Wei",
   "license": "MIT",


### PR DESCRIPTION
Apologies for the confusion—this was a typo:

Metadata only; no code changes.